### PR TITLE
Openai to azure openai

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+.venv
+.vscode

--- a/main.py
+++ b/main.py
@@ -2,21 +2,27 @@ from fastapi import FastAPI, Request, Form
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
-from openai import OpenAI
+from openai import AzureOpenAI
 
 from fastapi import Form
-import uvicorn
+from dotenv import load_dotenv
 
-# Initialize your OpenAI API key
-openai_api_key = "api_key"
-client = OpenAI(api_key=openai_api_key)
+import uvicorn
+import os
+
+load_dotenv()
+
+client = AzureOpenAI(
+    api_key=os.getenv("AZURE_OPENAI_API_KEY"),
+    api_version="2023-12-01-preview",
+    azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT")
+)
 
 app = FastAPI()
 
 # Mount static files
 app.mount("/static", StaticFiles(directory="static"), name="static")
 templates = Jinja2Templates(directory="static")
-
 
 @app.get("/", response_class=HTMLResponse)
 async def read_index(request: Request):
@@ -28,7 +34,8 @@ async def create_plan(request: Request, goal_input: str = Form(...)):
     goal = goal_input
 
     response = client.chat.completions.create(
-        model="gpt-3.5-turbo",
+        
+        model=os.getenv("AZURE_OPENAI_MODEL"),
         messages=[
             {"role": "user", "content": f"I want to achieve the following goal: {goal}. Can you create a simple plan to achieve this? Return the results in HTML format, but do not include the html and body tags."}
         ],

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ load_dotenv()
 
 client = AzureOpenAI(
     api_key=os.getenv("AZURE_OPENAI_API_KEY"),
-    api_version="2023-12-01-preview",
+    api_version=os.getenv("AZURE_OPENAI_API_VERSION"),
     azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT")
 )
 


### PR DESCRIPTION
This pull request primarily focuses on transitioning from using the OpenAI API to the AzureOpenAI API in the `main.py` file. The changes involve replacing the OpenAI client with the AzureOpenAI client, loading environment variables using the `dotenv` module, and fetching the AzureOpenAI API key and model from the environment variables. 

Environment setup and client initialization:

* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L5-L20): The OpenAI client is replaced with the AzureOpenAI client. The application now uses the `dotenv` module to load environment variables. The AzureOpenAI API key, API version, and endpoint are fetched from the environment variables.

API usage:

* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L31-R38): In the `create_plan` method, the model used for creating chat completions is fetched from the environment variables instead of being hard-coded.