### PR TITLE
create makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+# Define the default target
+.DEFAULT_GOAL := help
+
+# Define variables
+APP_MODULE := main:app
+APP_PORT := 8080
+
+# Define targets
+run:
+	.venv/bin/uvicorn $(APP_MODULE) --reload --port $(APP_PORT)
+
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@echo "  run       Start the application using uvicorn"
+	@echo "  help      use the command 'make run' to start the application"
+.PHONY: help


### PR DESCRIPTION
This pull request introduces changes to the `Makefile` to improve its usability and structure. The changes include defining a default target, setting up variables for the application module and port, and creating targets for running the application and displaying help instructions.

Here are the key changes:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R18): Defined a default target using `.DEFAULT_GOAL := help` to display help instructions when `make` is run without arguments.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R18): Introduced variables `APP_MODULE` and `APP_PORT` to hold the application module and port details respectively. This allows for easy modification of these values in the future.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R18): Created a `run` target that uses `uvicorn` to start the application with the defined module and port.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R18): Added a `help` target to provide usage instructions and list available targets when the `make help` command is run.